### PR TITLE
fix: replace hardcoded /Users/lain/ paths with $HOME in .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -118,7 +118,7 @@ man() {
 # Bun（JavaScriptランタイム）の設定
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
-[ -s "/Users/lain/.bun/_bun" ] && source "/Users/lain/.bun/_bun"
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
 
 # Envman（環境変数管理）の設定
 [ -s "$HOME/.config/envman/load.sh" ] && source "$HOME/.config/envman/load.sh"
@@ -129,4 +129,4 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 eval "$(atuin init zsh)"
 
 # Claude Code CLI のエイリアス
-alias claude="/Users/lain/.claude/local/claude"
+alias claude="$HOME/.claude/local/claude"


### PR DESCRIPTION
Fixes #6

Replaces hardcoded `/Users/lain/` paths with `$HOME` environment variable for better portability.

Changes:
- Bun completion script path (line 121)
- Claude CLI alias (line 132)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shell setup to correctly load development tools across different user environments by using home-directory variables, preventing failures on non-default machines.

* **Chores**
  * Updated shell configuration to remove user-specific absolute paths, improving portability and consistency for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->